### PR TITLE
minor tweaks to run in Debian Rodete, plus readme fixes

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -22,7 +22,7 @@ You may need:
  - bigdecimal gem
  - colored gem (for debugger)
  - rake (for web)
- - Electron (for new stencil)
+ - electron (for new stencil)
 
 You may want (only if you know you do):
  - Eclipse IDE. Suggested configuration files are kept in git.
@@ -35,7 +35,7 @@ a) cd to {ENSO_HOME}/src
 
 b) Run: ruby -I. {SOME RUBY FILE}
 
-  eg. ruby -I. core/expr/eval.rb
+  eg. ruby -I. core/expr/code/eval.rb
 
 You can add the following to your .bashrc to avoid the -I switch:
 
@@ -58,6 +58,7 @@ Refer to README in individual sample for running instructions.
 * Run GUI applications
     a)  cd {ENSO_HOME}/src/js
     b)  {path-to-electron}Electron .
+    alt b) npm install; npm start
       
       You can use CMD-O to open/edit many models. Examples include:
 		      ../core/schema/models/schema.schema 

--- a/src/core/system/load/cache.rb
+++ b/src/core/system/load/cache.rb
@@ -1,7 +1,7 @@
 require 'core/schema/tools/dumpjson'
 require 'core/system/utils/find_model'
 require 'digest/sha1'
-# require 'fileutils'
+require 'fileutils'
 
 module Cache
 

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,5 +1,12 @@
 {
-  "name"    : "enso",
-  "version" : "0.1.0",
-  "main"    : "main.js"
+  "name": "enso",
+  "version": "0.1.0",
+  "description": "Enso",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^3.0.4"
+  }
 }


### PR DESCRIPTION
small tweaks trying to use on Debian Rodete with ruby 2.3, nodejs 8.11 and electron 3.0.4